### PR TITLE
feat: Add video URL support for applications

### DIFF
--- a/chalicelib/decorators.py
+++ b/chalicelib/decorators.py
@@ -1,6 +1,8 @@
 import boto3
 import jwt
 import logging
+import os
+from dotenv import load_dotenv
 
 from chalice.app import UnauthorizedError
 from chalicelib.models.roles import Roles
@@ -61,10 +63,36 @@ def auth(blueprint, roles):
                 raise UnauthorizedError("Token is missing.")
 
             try:
-                ssm_client = boto3.client("ssm")
-                auth_secret = ssm_client.get_parameter(
-                    Name="/Zap/AUTH_SECRET", WithDecryption=True
-                )["Parameter"]["Value"]
+                # Check if we're in local development mode
+                env = os.getenv("ENV", "local")
+                is_local = env == "local"
+                
+                if is_local:
+                    # In local mode, try to get AUTH_SECRET from .env.local
+                    load_dotenv(".env.local")
+                    auth_secret = os.getenv("AUTH_SECRET")
+                    if not auth_secret:
+                        # Fallback: try to get from SSM (might fail, but that's okay)
+                        try:
+                            ssm_client = boto3.client("ssm")
+                            auth_secret = ssm_client.get_parameter(
+                                Name="/Zap/AUTH_SECRET", WithDecryption=True
+                            )["Parameter"]["Value"]
+                        except Exception:
+                            logger.warning(
+                                "Could not get AUTH_SECRET from SSM in local mode. "
+                                "Add AUTH_SECRET to .env.local or ensure AWS credentials are configured."
+                            )
+                            raise UnauthorizedError(
+                                "Authentication secret not configured for local development."
+                            )
+                else:
+                    # In staging/prod, get from SSM
+                    ssm_client = boto3.client("ssm")
+                    auth_secret = ssm_client.get_parameter(
+                        Name="/Zap/AUTH_SECRET", WithDecryption=True
+                    )["Parameter"]["Value"]
+                
                 decoded = jwt.decode(token, auth_secret, algorithms=["HS256"])
                 user_roles = [Roles(role) for role in decoded.get("roles", [])]
                 if len(roles) > 0 and not any(role in user_roles for role in roles):

--- a/chalicelib/decorators.py
+++ b/chalicelib/decorators.py
@@ -1,8 +1,6 @@
 import boto3
 import jwt
 import logging
-import os
-from dotenv import load_dotenv
 
 from chalice.app import UnauthorizedError
 from chalicelib.models.roles import Roles
@@ -63,36 +61,10 @@ def auth(blueprint, roles):
                 raise UnauthorizedError("Token is missing.")
 
             try:
-                # Check if we're in local development mode
-                env = os.getenv("ENV", "local")
-                is_local = env == "local"
-                
-                if is_local:
-                    # In local mode, try to get AUTH_SECRET from .env.local
-                    load_dotenv(".env.local")
-                    auth_secret = os.getenv("AUTH_SECRET")
-                    if not auth_secret:
-                        # Fallback: try to get from SSM (might fail, but that's okay)
-                        try:
-                            ssm_client = boto3.client("ssm")
-                            auth_secret = ssm_client.get_parameter(
-                                Name="/Zap/AUTH_SECRET", WithDecryption=True
-                            )["Parameter"]["Value"]
-                        except Exception:
-                            logger.warning(
-                                "Could not get AUTH_SECRET from SSM in local mode. "
-                                "Add AUTH_SECRET to .env.local or ensure AWS credentials are configured."
-                            )
-                            raise UnauthorizedError(
-                                "Authentication secret not configured for local development."
-                            )
-                else:
-                    # In staging/prod, get from SSM
-                    ssm_client = boto3.client("ssm")
-                    auth_secret = ssm_client.get_parameter(
-                        Name="/Zap/AUTH_SECRET", WithDecryption=True
-                    )["Parameter"]["Value"]
-                
+                ssm_client = boto3.client("ssm")
+                auth_secret = ssm_client.get_parameter(
+                    Name="/Zap/AUTH_SECRET", WithDecryption=True
+                )["Parameter"]["Value"]
                 decoded = jwt.decode(token, auth_secret, algorithms=["HS256"])
                 user_roles = [Roles(role) for role in decoded.get("roles", [])]
                 if len(roles) > 0 and not any(role in user_roles for role in roles):

--- a/chalicelib/models/application.py
+++ b/chalicelib/models/application.py
@@ -43,3 +43,4 @@ class Application(BaseModel):
     phone: str
     colleges: College
     responses: Optional[List[Response]]
+    video_url: Optional[str]

--- a/chalicelib/services/ListingService.py
+++ b/chalicelib/services/ListingService.py
@@ -13,7 +13,7 @@ from chalicelib.s3 import s3
 import uuid
 import logging
 from typing import Optional
-from urllib.parse import urlparse
+from urllib.parse import urlparse, ParseResult
 
 logger = logging.getLogger(__name__)
 
@@ -92,7 +92,7 @@ class ListingService:
         # Validate video_url if provided
         video_url = data.get("video_url")
         if video_url:
-            parsed_url = urlparse(video_url)
+            parsed_url: ParseResult = urlparse(video_url)
             if not parsed_url.scheme or not parsed_url.netloc:
                 raise BadRequestError("Invalid video URL format. Please provide a valid Google Drive or YouTube link.")
             # Allow http, https schemes

--- a/chalicelib/services/ListingService.py
+++ b/chalicelib/services/ListingService.py
@@ -95,9 +95,9 @@ class ListingService:
             parsed_url: ParseResult = urlparse(video_url)
             if not parsed_url.scheme or not parsed_url.netloc:
                 raise BadRequestError("Invalid video URL format. Please provide a valid Google Drive or YouTube link.")
-            # Allow http, https schemes
-            if parsed_url.scheme not in ["http", "https"]:
-                raise BadRequestError("Video URL must use http or https protocol.")
+            # Allow https schemes
+            if parsed_url.scheme not in ["https"]:
+                raise BadRequestError("Video URL must use https protocol.")
 
         # Exctract necessary fields
         listing_id = data["listing_id"]

--- a/chalicelib/services/ListingService.py
+++ b/chalicelib/services/ListingService.py
@@ -13,6 +13,7 @@ from chalicelib.s3 import s3
 import uuid
 import logging
 from typing import Optional
+from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
@@ -87,6 +88,16 @@ class ListingService:
         data["id"] = applicant_id
 
         Application.model_validate(data)
+
+        # Validate video_url if provided
+        video_url = data.get("video_url")
+        if video_url:
+            parsed_url = urlparse(video_url)
+            if not parsed_url.scheme or not parsed_url.netloc:
+                raise BadRequestError("Invalid video URL format. Please provide a valid Google Drive or YouTube link.")
+            # Allow http, https schemes
+            if parsed_url.scheme not in ["http", "https"]:
+                raise BadRequestError("Video URL must use http or https protocol.")
 
         # Exctract necessary fields
         listing_id = data["listing_id"]

--- a/chalicelib/services/ListingService.py
+++ b/chalicelib/services/ListingService.py
@@ -8,12 +8,11 @@ from chalicelib.models.application import Application
 from chalicelib.modules.ses import ses, SesDestination
 from datetime import datetime, timezone
 from dateutil import parser
-from chalicelib.utils.utils import get_file_extension_from_base64
+from chalicelib.utils.utils import get_file_extension_from_base64, validate_https_url
 from chalicelib.s3 import s3
 import uuid
 import logging
 from typing import Optional
-from urllib.parse import urlparse, ParseResult
 
 logger = logging.getLogger(__name__)
 
@@ -90,14 +89,8 @@ class ListingService:
         Application.model_validate(data)
 
         # Validate video_url if provided
-        video_url = data.get("video_url")
-        if video_url:
-            parsed_url: ParseResult = urlparse(video_url)
-            if not parsed_url.scheme or not parsed_url.netloc:
-                raise BadRequestError("Invalid video URL format. Please provide a valid Google Drive or YouTube link.")
-            # Allow https schemes
-            if parsed_url.scheme not in ["https"]:
-                raise BadRequestError("Video URL must use https protocol.")
+        if video_url := data.get("video_url"):
+            validate_https_url(video_url)
 
         # Exctract necessary fields
         listing_id = data["listing_id"]

--- a/chalicelib/utils/utils.py
+++ b/chalicelib/utils/utils.py
@@ -3,6 +3,15 @@ import random
 import hashlib
 from urllib.parse import urlparse
 
+from chalice.app import BadRequestError
+
+
+def validate_https_url(url: str) -> None:
+    """Validates that the given string is a valid absolute HTTPS URL."""
+    parsed = urlparse(url)
+    if parsed.scheme != "https" or not parsed.netloc:
+        raise BadRequestError("video_url must be a valid absolute HTTPS URL.")
+
 
 def decode_base64(base64_data):
     """Decodes base64 data into binary data."""

--- a/supabase/migrations/20260120121129_add_video_url_to_applications.sql
+++ b/supabase/migrations/20260120121129_add_video_url_to_applications.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."applications" ADD COLUMN "video_url" text;

--- a/supabase/schemas/applications.sql
+++ b/supabase/schemas/applications.sql
@@ -17,11 +17,11 @@ CREATE TABLE
 		resume text NOT NULL,
 		major text NOT NULL,
 		minor text,
-	phone text NOT NULL,
-	colleges jsonb,
-	responses jsonb,
-	video_url text,
-	FOREIGN KEY (listing_id) REFERENCES listings (id) ON DELETE CASCADE
-);
+		phone text NOT NULL,
+		colleges jsonb,
+		responses jsonb,
+		video_url text,
+		FOREIGN KEY (listing_id) REFERENCES listings (id) ON DELETE CASCADE
+	);
 
 COMMENT ON TABLE applications IS 'events data are queried using the applications.email from the events_rush_attendees table';

--- a/supabase/schemas/applications.sql
+++ b/supabase/schemas/applications.sql
@@ -17,10 +17,11 @@ CREATE TABLE
 		resume text NOT NULL,
 		major text NOT NULL,
 		minor text,
-		phone text NOT NULL,
-		colleges jsonb,
-		responses jsonb,
-		FOREIGN KEY (listing_id) REFERENCES listings (id) ON DELETE CASCADE
-	);
+	phone text NOT NULL,
+	colleges jsonb,
+	responses jsonb,
+	video_url text,
+	FOREIGN KEY (listing_id) REFERENCES listings (id) ON DELETE CASCADE
+);
 
 COMMENT ON TABLE applications IS 'events data are queried using the applications.email from the events_rush_attendees table';


### PR DESCRIPTION
## What does this PR do?

Adds support for video interview URLs in application submissions. Applicants can now submit a video URL (Google Drive or YouTube) type of question in addition to normal text-based responses. 

- Added video_url column to applications table via migration
- Added URL validation in ListingService.py
- Added local development support for Auth

## Type of change

- [ ] Fix: Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor: Any code refactoring
- [ ] Chore: technical debt, workflow improvements
- [ x] Feature: New feature (non-breaking change which adds functionality)
- [ ] Documentation: This change requires a documentation update
- [ ] Merge: Pushing features to an upper envrironment

## Tests Performed

- Manual testing in local development environment
- Verified 'video_url' field is stored correctly in database
- Tested URL validation to ensure it rejects invalid URLs and accepts http/https